### PR TITLE
Add ability to consume published items as list

### DIFF
--- a/src/main/java/pl/rzrz/assertj/reactor/PublisherAssert.java
+++ b/src/main/java/pl/rzrz/assertj/reactor/PublisherAssert.java
@@ -76,6 +76,14 @@ public class PublisherAssert<T> extends AbstractAssert<PublisherAssert<T>, Publi
         return emitsExactly(Arrays.asList(expectedItems));
     }
 
+    public PublisherAssert<T> emitsItems(Consumer<List<T>> assertions) {
+        if (result.hasError()) {
+            failWithMessage("Publisher sent an error: %s", result.getError());
+        }
+        assertions.accept(result.getItems());
+        return this;
+    }
+
     private PublisherAssert<T> emitsExactly(List<T> expectedItems) {
 
         if (result.getItems().size() != expectedItems.size()) {


### PR DESCRIPTION
This way you are able to run assertions on the items, rather than just matching them